### PR TITLE
Correct Docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ docker run -it \
 	-v /etc:/rootfs/etc \
 	-v /opt:/rootfs/opt \
 	-v /usr/bin:/rootfs/usr/bin \
-	luxas/kubeadm-installer ${your_os_here}
+	xakra/kubeadm-installer:0.4.5 ${your_os_here}
 ```
 
 `${your_os_here}` can be `coreos`, `ubuntu`, `debian`, `fedora` or `centos`
@@ -38,7 +38,7 @@ $ docker run -it 	\
 	-v /etc:/rootfs/etc \
 	-v /opt:/rootfs/opt \
 	-v /usr/bin:/rootfs/usr/bin \
-	luxas/kubeadm-installer ${your_os_here} uninstall
+	xakra/kubeadm-installer:0.4.5 ${your_os_here} uninstall
 ```
 
 

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -145,7 +145,7 @@ cat <<-EOF
     -v /etc/:/rootfs/etc \
     -v /usr:/rootfs/usr \
     -v /opt:/rootfs/opt \
-    luxas/kubeadm-installer your_os_here
+    xakra/kubeadm-installer your_os_here
 
   your_os_here can be coreos, ubuntu, debian, fedora or centos
 
@@ -154,7 +154,7 @@ cat <<-EOF
     -v /etc/:/rootfs/etc \
     -v /usr:/rootfs/usr \
     -v /opt:/rootfs/opt \
-    luxas/kubeadm-installer your_os_here uninstall
+    xakra/kubeadm-installer your_os_here uninstall
 EOF
 exit 1
 fi
@@ -165,7 +165,7 @@ fi
 set -o errexit
 set -o nounset
 
-if [[ $2 == "uninstall" ]]; then
+if [[ $# -gt 2 ]] && [[ $2 == "uninstall" ]]; then
   rm -rfv ${ROOTFS}/etc/cni \
     ${ROOTFS}/${BIN_DIR}/kubectl \
     ${ROOTFS}/${BIN_DIR}/kubelet \


### PR DESCRIPTION
Point to the correct Docker image (not the old one). Also I needed to add a simple check if there is a second parameter provided otherwise the container will exit with the error message `unbound variable`.